### PR TITLE
Install MonitorControl on macOS setup

### DIFF
--- a/installation/macos
+++ b/installation/macos
@@ -94,6 +94,8 @@ function install_macos() {
   fi
 
   brew_cask_install_if_absent rectangle
+  # Brightness/volume control for external monitors over DDC
+  brew_cask_install_if_absent monitorcontrol
   brew_cask_install_if_absent slack
   brew_cask_install_if_absent 1password
   brew_cask_install_if_absent font-libre-caslon-text


### PR DESCRIPTION
## Summary

Adds [MonitorControl](https://github.com/MonitorControl/MonitorControl) to the macOS install script so external-monitor brightness and volume control is set up on a fresh machine instead of being installed by hand.

## Change

One line in `installation/macos`, alongside the other utility casks:

```bash
brew_cask_install_if_absent monitorcontrol
```

## Notes

- Base is `fix/fresh-machine-install` rather than `master`, since that branch has unmerged commits touching this same file.
- `brew info --cask monitorcontrol` resolves to MonitorControl 4.3.3, homepage `github.com/MonitorControl/MonitorControl`.
- `bash -n installation/macos` passes; the existing `brew_cask_install_if_absent` guard makes re-runs a no-op.
- MonitorControl needs Accessibility permission granted interactively in System Settings on first launch, which the script cannot automate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)